### PR TITLE
Add support for OpenEXR v3

### DIFF
--- a/components/pango_image/src/image_io_exr.cpp
+++ b/components/pango_image/src/image_io_exr.cpp
@@ -1,10 +1,12 @@
 #include <pangolin/platform.h>
 
+#include <cstdint>
 #include <fstream>
 #include <pangolin/image/typed_image.h>
 
 #ifdef HAVE_OPENEXR
 #include <ImfChannelList.h>
+#include <ImfFrameBuffer.h>
 #include <ImfInputFile.h>
 #include <ImfOutputFile.h>
 #include <ImfIO.h>
@@ -54,12 +56,12 @@ class StdIStream: public Imf::IStream
         return true;
     }
 
-    virtual Imf::Int64 tellg ()
+    virtual uint64_t tellg ()
     {
         return std::streamoff (_is->tellg());
     }
 
-    virtual void seekg (Imf::Int64 pos)
+    virtual void seekg (uint64_t pos)
     {
         _is->seekg (pos);
     }


### PR DESCRIPTION
`image_io_exr.cpp` needs only a couple very minor tweaks to support both OpenEXR versions 2 and 3.
- Fixes #649.

Build logs:
- [pangolin-openexr-v2.log](https://github.com/user-attachments/files/19247478/pangolin-openexr-v2.log)
- [pangolin-openexr-v3.log](https://github.com/user-attachments/files/19247477/pangolin-openexr-v3.log)
